### PR TITLE
Fix deploy: upload only site files instead of entire repo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,13 +22,19 @@ jobs:
       - name: Generate posts index
         run: python3 build.py
 
+      - name: Prepare site
+        run: |
+          mkdir -p _site
+          cp index.html post.html style.css posts.json .nojekyll _site/
+          cp -r posts _site/
+
       - name: Setup Pages
         uses: actions/configure-pages@v5
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: .
+          path: _site
 
   deploy:
     needs: build


### PR DESCRIPTION
## Summary

- Fix GitHub Actions deploy by copying only necessary site files to `_site/` directory before uploading
- Previous workflow uploaded `path: .` which included `.git/` and other repo files, likely causing the deploy failure

## Changes

The build step now explicitly copies only the needed files:
```
index.html, post.html, style.css, posts.json, .nojekyll, posts/
```

## Note

Make sure GitHub Pages source is set to **GitHub Actions** in repo Settings > Pages (not "Deploy from a branch").

https://claude.ai/code/session_016WT6NiqdZHRYrNtGj47npt