### PR TITLE
Fix deploy: use gh-pages branch instead of deploy-pages action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,16 +5,14 @@ on:
     branches: [main]
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 concurrency:
   group: pages
   cancel-in-progress: true
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -28,21 +26,8 @@ jobs:
           cp index.html post.html style.css posts.json .nojekyll _site/
           cp -r posts _site/
 
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+      - name: Deploy to gh-pages branch
+        uses: peaceiris/actions-gh-pages@v4
         with:
-          path: _site
-
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./_site


### PR DESCRIPTION
## Summary

- Fix: `deploy-pages` action failed because GitHub Pages is configured to deploy from `gh-pages` branch, not via Actions OIDC
- Switch to `peaceiris/actions-gh-pages@v4` which pushes the built site to the `gh-pages` branch
- Fix: post rendering error — the `.catch()` was catching Marked/Mermaid/KaTeX rendering errors and showing "Post não encontrado" even when the post was fetched successfully. Separated fetch error handling from rendering.

## Test plan
- [ ] Verify deploy workflow succeeds on push to `main`
- [ ] Verify the welcome post renders correctly on the live site

https://claude.ai/code/session_016WT6NiqdZHRYrNtGj47npt