### PR TITLE
Fix post rendering: separate fetch errors from render errors

### DIFF
--- a/post.html
+++ b/post.html
@@ -73,14 +73,19 @@
     if (file) {
       fetch('posts/' + file)
         .then(r => { if (!r.ok) throw new Error(); return r.text(); })
+        .catch(() => {
+          document.getElementById('content').textContent = 'Post não encontrado.';
+          return null;
+        })
         .then(md => {
+          if (!md) return;
           const { meta, body } = parseFrontMatter(md);
           if (meta.title) document.title = meta.title + ' — maycommit';
           document.getElementById('meta').textContent = [meta.date, meta.title].filter(Boolean).join(' · ');
           document.getElementById('content').innerHTML = marked.parse(body);
 
           // Render mermaid diagrams
-          mermaid.run({ querySelector: '.mermaid' });
+          mermaid.run({ querySelector: '.mermaid' }).catch(() => {});
 
           // Render KaTeX math
           renderMathInElement(document.getElementById('content'), {
@@ -92,9 +97,6 @@
             ],
             throwOnError: false
           });
-        })
-        .catch(() => {
-          document.getElementById('content').textContent = 'Post não encontrado.';
         });
     }
   </script>


### PR DESCRIPTION
## Summary

- The `.catch()` in `post.html` was catching **all** errors, including rendering errors from Marked/Mermaid/KaTeX
- The fetch succeeds (metadata appears correctly), but a rendering error triggers the catch and overwrites the content with "Post não encontrado."
- Moved catch to only handle fetch errors; mermaid errors are silenced separately

## Test plan
- [ ] Open the welcome post and verify it renders correctly
- [ ] Verify "Post não encontrado" only appears for actually missing posts

https://claude.ai/code/session_016WT6NiqdZHRYrNtGj47npt