### PR TITLE
Fix marked v14: use marked.use() instead of deprecated API

### DIFF
--- a/post.html
+++ b/post.html
@@ -41,22 +41,21 @@
   <script>
     mermaid.initialize({ startOnLoad: false, theme: 'neutral' });
 
-    const renderer = new marked.Renderer();
-
-    // Intercept code blocks for mermaid
-    const originalCode = renderer.code.bind(renderer);
-    renderer.code = function({ text, lang }) {
-      if (lang === 'mermaid') {
-        return `<div class="mermaid">${text}</div>`;
+    marked.use({
+      renderer: {
+        code({ text, lang }) {
+          if (lang === 'mermaid') {
+            return `<div class="mermaid">${text}</div>`;
+          }
+          if (lang && hljs.getLanguage(lang)) {
+            const highlighted = hljs.highlight(text, { language: lang }).value;
+            return `<pre><code class="hljs language-${lang}">${highlighted}</code></pre>`;
+          }
+          const escaped = text.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+          return `<pre><code>${escaped}</code></pre>`;
+        }
       }
-      if (lang && hljs.getLanguage(lang)) {
-        const highlighted = hljs.highlight(text, { language: lang }).value;
-        return `<pre><code class="hljs language-${lang}">${highlighted}</code></pre>`;
-      }
-      return `<pre><code>${text.replace(/</g, '&lt;').replace(/>/g, '&gt;')}</code></pre>`;
-    };
-
-    marked.setOptions({ renderer });
+    });
 
     function parseFrontMatter(md) {
       const match = md.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);


### PR DESCRIPTION
## Summary

- `marked` v14 requires `marked.use({ renderer })` instead of `new marked.Renderer()` + `marked.setOptions()`
- The deprecated API caused `marked.parse()` to fail silently, leaving the page stuck on "Carregando..."
- This is the root cause of the post not rendering

## Test plan
- [ ] Open the welcome post and verify markdown renders correctly
- [ ] Verify code blocks, mermaid diagrams, and KaTeX formulas render

https://claude.ai/code/session_016WT6NiqdZHRYrNtGj47npt