### PR TITLE
Add function-plot graphs and translate to English

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="pt-BR">
+<html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -28,7 +28,7 @@
         });
       })
       .catch(() => {
-        document.getElementById('posts').innerHTML = '<li>Nenhum post ainda.</li>';
+        document.getElementById('posts').innerHTML = '<li>No posts yet.</li>';
       });
   </script>
 </body>

--- a/post.html
+++ b/post.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="pt-BR">
+<html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -25,6 +25,9 @@
   <script src="https://cdn.jsdelivr.net/npm/@highlightjs/cdn-assets@11/languages/yaml.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/@highlightjs/cdn-assets@11/languages/json.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/@highlightjs/cdn-assets@11/languages/rust.min.js"></script>
+  <!-- Function Plot (math graphing) -->
+  <script src="https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/function-plot@1/dist/function-plot.js"></script>
 </head>
 <body>
   <header>
@@ -33,10 +36,10 @@
   <main>
     <article>
       <div class="post-meta" id="meta"></div>
-      <div class="post-content" id="content">Carregando...</div>
+      <div class="post-content" id="content">Loading...</div>
     </article>
   </main>
-  <footer><a href="/">&larr; voltar</a></footer>
+  <footer><a href="/">&larr; back</a></footer>
 
   <script>
     mermaid.initialize({ startOnLoad: false, theme: 'neutral' });
@@ -47,6 +50,10 @@
           if (lang === 'mermaid') {
             return `<div class="mermaid">${text}</div>`;
           }
+          if (lang === 'functionplot') {
+            const id = 'plot-' + Math.random().toString(36).slice(2, 9);
+            return `<div class="function-plot" id="${id}" data-plot="${text.replace(/"/g, '&quot;')}"></div>`;
+          }
           if (lang && hljs.getLanguage(lang)) {
             const highlighted = hljs.highlight(text, { language: lang }).value;
             return `<pre><code class="hljs language-${lang}">${highlighted}</code></pre>`;
@@ -56,6 +63,56 @@
         }
       }
     });
+
+    function parsePlotConfig(text) {
+      const lines = text.trim().split('\n');
+      const fns = [];
+      const opts = {};
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        const kvMatch = trimmed.match(/^(\w+)\s*=\s*(.+)$/);
+        if (kvMatch) {
+          const key = kvMatch[1];
+          const val = kvMatch[2].trim();
+          if (key === 'xDomain' || key === 'yDomain') {
+            const nums = val.replace(/[\[\]]/g, '').split(',').map(Number);
+            opts[key] = nums;
+          } else if (key === 'title') {
+            opts.title = val;
+          } else {
+            // treat as function definition: fn = expression
+            fns.push({ fn: val, color: undefined });
+          }
+        } else {
+          // bare line = function expression
+          fns.push({ fn: trimmed });
+        }
+      }
+      return { fns, opts };
+    }
+
+    function renderPlots() {
+      document.querySelectorAll('.function-plot').forEach(el => {
+        const raw = el.getAttribute('data-plot');
+        if (!raw) return;
+        const { fns, opts } = parsePlotConfig(raw);
+        try {
+          functionPlot({
+            target: '#' + el.id,
+            width: Math.min(el.parentElement.offsetWidth, 700),
+            height: 400,
+            xAxis: opts.xDomain ? { domain: opts.xDomain } : undefined,
+            yAxis: opts.yDomain ? { domain: opts.yDomain } : undefined,
+            title: opts.title,
+            grid: true,
+            data: fns.map(f => ({ fn: f.fn, graphType: 'polyline' }))
+          });
+        } catch (e) {
+          el.textContent = 'Plot error: ' + e.message;
+        }
+      });
+    }
 
     function parseFrontMatter(md) {
       const match = md.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
@@ -73,7 +130,7 @@
       fetch('posts/' + file)
         .then(r => { if (!r.ok) throw new Error(); return r.text(); })
         .catch(() => {
-          document.getElementById('content').textContent = 'Post não encontrado.';
+          document.getElementById('content').textContent = 'Post not found.';
           return null;
         })
         .then(md => {
@@ -85,6 +142,9 @@
 
           // Render mermaid diagrams
           mermaid.run({ querySelector: '.mermaid' }).catch(() => {});
+
+          // Render function plots
+          renderPlots();
 
           // Render KaTeX math
           renderMathInElement(document.getElementById('content'), {

--- a/posts/2026-03-24-bem-vindo.md
+++ b/posts/2026-03-24-bem-vindo.md
@@ -1,15 +1,15 @@
 ---
-title: Bem-vindo ao blog
+title: Welcome to the blog
 date: 2026-03-24
 ---
 
-# Bem-vindo
+# Welcome
 
-Este blog suporta **Markdown**, diagramas e fórmulas matemáticas.
+This blog supports **Markdown**, diagrams, math formulas, and function graphs.
 
-## Diagramas com Mermaid
+## Diagrams with Mermaid
 
-Diagrama de sequência:
+Sequence diagram:
 
 ```mermaid
 sequenceDiagram
@@ -22,22 +22,22 @@ sequenceDiagram
     Server-->>Client: 201 Created
 ```
 
-Caso de uso:
+Use case:
 
 ```mermaid
 graph LR
-    User((Usuário))
+    User((User))
     User --> Login[Login]
-    User --> ViewPosts[Ver Posts]
-    User --> CreatePost[Criar Post]
+    User --> ViewPosts[View Posts]
+    User --> CreatePost[Create Post]
     Admin((Admin))
-    Admin --> ManageUsers[Gerenciar Usuários]
+    Admin --> ManageUsers[Manage Users]
     Admin --> CreatePost
 ```
 
-## Fórmulas com KaTeX
+## Math with KaTeX
 
-Inline: a famosa equação de Euler $e^{i\pi} + 1 = 0$.
+Inline: Euler's famous equation $e^{i\pi} + 1 = 0$.
 
 Display mode:
 
@@ -45,13 +45,33 @@ $$
 \int_{-\infty}^{\infty} e^{-x^2} dx = \sqrt{\pi}
 $$
 
-Bayes:
+Bayes' theorem:
 
 $$
 P(A|B) = \frac{P(B|A) \cdot P(A)}{P(B)}
 $$
 
-## Código
+## Graphs with Function Plot
+
+Sine and cosine:
+
+```functionplot
+sin(x)
+cos(x)
+xDomain = [-2 * PI, 2 * PI]
+yDomain = [-1.5, 1.5]
+```
+
+A parabola and its derivative:
+
+```functionplot
+x^2
+2 * x
+xDomain = [-3, 3]
+yDomain = [-2, 9]
+```
+
+## Code
 
 ```python
 def fibonacci(n):
@@ -61,14 +81,14 @@ def fibonacci(n):
     return a
 ```
 
-## Como usar
+## How to use
 
-1. Crie um arquivo `.md` em `posts/` com front matter:
+1. Create a `.md` file in `posts/` with front matter:
    ```yaml
    ---
-   title: Meu Post
+   title: My Post
    date: 2026-03-24
    ---
    ```
-2. Faça push para `main`
-3. O CI gera o `posts.json` automaticamente
+2. Push to `main`
+3. CI generates `posts.json` automatically

--- a/style.css
+++ b/style.css
@@ -70,6 +70,10 @@ header p { color: #666; font-size: 0.9rem; margin-top: 0.25rem; }
 /* Mermaid */
 .mermaid { margin: 1rem 0; text-align: center; }
 
+/* Function Plot */
+.function-plot { margin: 1rem 0; }
+.function-plot svg { max-width: 100%; height: auto; }
+
 /* KaTeX overrides */
 .katex-display { margin: 1rem 0; overflow-x: auto; }
 


### PR DESCRIPTION
## Summary

- Integrate **function-plot** library for rendering math graphs from ` ```functionplot ` code blocks (similar to mermaid)
- Translate all UI text to English (index page, post page, welcome post)
- Add graph examples to welcome post: sin/cos waves and parabola with derivative

## Syntax

````
```functionplot
sin(x)
cos(x)
xDomain = [-2 * PI, 2 * PI]
yDomain = [-1.5, 1.5]
```
````

Supports: function expressions (one per line), `xDomain`, `yDomain`, `title` options.

## Test plan
- [ ] Verify all UI text is in English
- [ ] Verify function-plot graphs render on the welcome post
- [ ] Verify mermaid, KaTeX, and code highlighting still work

https://claude.ai/code/session_016WT6NiqdZHRYrNtGj47npt