### PR TITLE
Fix function-plot: evaluate PI/E in domain expressions

### DIFF
--- a/post.html
+++ b/post.html
@@ -76,7 +76,7 @@
           const key = kvMatch[1];
           const val = kvMatch[2].trim();
           if (key === 'xDomain' || key === 'yDomain') {
-            const nums = val.replace(/[\[\]]/g, '').split(',').map(Number);
+            const nums = val.replace(/[\[\]]/g, '').split(',').map(s => Function('"use strict"; return (' + s.replace(/PI/g, 'Math.PI').replace(/E(?!\w)/g, 'Math.E') + ')')());
             opts[key] = nums;
           } else if (key === 'title') {
             opts.title = val;


### PR DESCRIPTION
## Summary

- `xDomain = [-2 * PI, 2 * PI]` was parsed with `Number()` which returned `NaN` for math expressions
- Now evaluates expressions properly, replacing `PI` → `Math.PI` and `E` → `Math.E`
- Fixes the "undefined is not an object" error on the sine/cosine plot

## Test plan
- [ ] Verify sine/cosine graph renders with PI domain
- [ ] Verify parabola graph still works

https://claude.ai/code/session_016WT6NiqdZHRYrNtGj47npt